### PR TITLE
add more precise current time label

### DIFF
--- a/EditorChanges.csproj
+++ b/EditorChanges.csproj
@@ -76,6 +76,7 @@
 	<Compile Include="Patches\ChangeKeybindsDisplay.cs" />
 	<Compile Include="Patches\InvisColorSwap.cs" />
 	<Compile Include="Patches\InvisToggle.cs" />
+    <Compile Include="Patches\DisplayPreciseTime.cs"/>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Patch.cs
+++ b/Patch.cs
@@ -94,6 +94,8 @@ namespace EditorChanges {
                 Logger.LogInfo("Enabled Invisibility");
             }
 
+            Harmony.CreateAndPatchAll(typeof(DisplayPreciseTime));
+
         }
 
         /*

--- a/Patches/DisplayPreciseTime.cs
+++ b/Patches/DisplayPreciseTime.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Reflection.Emit;
+using BepInEx.Logging;
+using HarmonyLib;
+
+namespace EditorChanges
+{
+    public static class DisplayPreciseTime
+    {
+        [HarmonyPatch(typeof(TrackEditorGUI), "UpdateTrackInfoDetailsPanel")]
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> ChangeStringTimeFormat(IEnumerable<CodeInstruction> instructions)
+        {
+            var code = new List<CodeInstruction>(instructions);
+
+            for (int i = 0; i < code.Count; i++)
+            {
+                if (code[i].opcode == OpCodes.Ldstr && (string) code[i].operand == "0.00")
+                {
+                    code[i].operand = "0.0000";
+                    break;
+                }
+            }
+            
+            Patch.logger.LogInfo("Transpiled time!");
+
+            return code;
+        }
+    }
+}


### PR DESCRIPTION
Extends the track time value by two extra digits, useful for Chroma/DTS trigger timing